### PR TITLE
Feat: Improve UI/UX and Performance for Search

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,6 +1,10 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
 
+// Quick win for caching
+export const dynamic = "force-static";
+export const revalidate = 60;
+
 export async function GET() {
   try {
     const data = await db.select().from(advocates);

--- a/src/app/components/AdvocatesFilters.tsx
+++ b/src/app/components/AdvocatesFilters.tsx
@@ -1,0 +1,62 @@
+import { ActiveFilterValues, DynamicFilterOptions } from "../shared/types";
+import { CategoryFilter } from "./CategoryFilter";
+import { RangeFilter } from "./RangeFilter";
+
+type AdvocatesFiltersProps = {
+  activeFilters: ActiveFilterValues;
+  setActiveFilters: (activeFilters: ActiveFilterValues) => void;
+  dynamicFilterOptions: DynamicFilterOptions;
+  experienceRanges: { label: string; min: number; max: number }[];
+};
+
+// TODO: This whole component could be broken down further and made more generic.
+export const AdvocatesFilters = ({
+  activeFilters,
+  setActiveFilters,
+  dynamicFilterOptions,
+  experienceRanges,
+}: AdvocatesFiltersProps) => {
+  return (
+    <div className="flex flex-wrap gap-4">
+      <CategoryFilter
+        id="specialty"
+        label="Specialty"
+        options={dynamicFilterOptions.specialties}
+        value={activeFilters.specialty}
+        onChange={(value) =>
+          setActiveFilters({ ...activeFilters, specialty: value })
+        }
+      />
+
+      <CategoryFilter
+        id="city"
+        label="City"
+        options={dynamicFilterOptions.cities}
+        value={activeFilters.city}
+        onChange={(value) =>
+          setActiveFilters({ ...activeFilters, city: value })
+        }
+      />
+
+      <CategoryFilter
+        id="degree"
+        label="Degree"
+        options={dynamicFilterOptions.degrees}
+        value={activeFilters.degree}
+        onChange={(value) =>
+          setActiveFilters({ ...activeFilters, degree: value })
+        }
+      />
+
+      <RangeFilter
+        id="experienceRange"
+        label="Years of Experience"
+        ranges={experienceRanges}
+        value={activeFilters.experienceRange}
+        onChange={(value) =>
+          setActiveFilters({ ...activeFilters, experienceRange: value })
+        }
+      />
+    </div>
+  );
+};

--- a/src/app/components/AdvocatesTable.tsx
+++ b/src/app/components/AdvocatesTable.tsx
@@ -1,0 +1,74 @@
+import { Advocate } from "../shared/types";
+
+type AdvocatesTableProps = {
+  advocates: Advocate[];
+};
+
+export const AdvocatesTable = ({ advocates }: AdvocatesTableProps) => (
+  <div className="overflow-x-auto">
+    <table className="w-full table-auto border-collapse border border-gray-200 text-sm">
+      <thead className="bg-gray-100 text-gray-600 uppercase text-xs font-semibold">
+        <tr>
+          <th className="border border-gray-300 px-4 py-2 text-left">
+            First Name
+          </th>
+          <th className="border border-gray-300 px-4 py-2 text-left">
+            Last Name
+          </th>
+          <th className="border border-gray-300 px-4 py-2 text-left">City</th>
+          <th className="border border-gray-300 px-4 py-2 text-left">Degree</th>
+          <th className="border border-gray-300 px-4 py-2 text-left hidden md:table-cell">
+            Specialties
+          </th>
+          <th className="border border-gray-300 px-4 py-2 text-left">
+            Years of Experience
+          </th>
+          <th className="border border-gray-300 px-4 py-2 text-left hidden sm:table-cell">
+            Contact
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {advocates.length === 0 ? (
+          <tr>
+            <td
+              colSpan={7}
+              className="border border-gray-300 px-4 py-6 text-center text-gray-600"
+            >
+              No advocates found.
+            </td>
+          </tr>
+        ) : (
+          advocates.map((advocate) => (
+            <tr
+              key={advocate.id}
+              className="hover:bg-gray-50 transition-colors duration-200"
+            >
+              <td className="border border-gray-300 px-4 py-2">
+                {advocate.firstName}
+              </td>
+              <td className="border border-gray-300 px-4 py-2">
+                {advocate.lastName}
+              </td>
+              <td className="border border-gray-300 px-4 py-2">
+                {advocate.city}
+              </td>
+              <td className="border border-gray-300 px-4 py-2">
+                {advocate.degree}
+              </td>
+              <td className="border border-gray-300 px-4 py-2 hidden md:table-cell">
+                {advocate.specialties.join(", ")}
+              </td>
+              <td className="border border-gray-300 px-4 py-2">
+                {advocate.yearsOfExperience}
+              </td>
+              <td className="border border-gray-300 px-4 py-2 hidden sm:table-cell">
+                {advocate.phoneNumber}
+              </td>
+            </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  </div>
+);

--- a/src/app/components/CategoryFilter.tsx
+++ b/src/app/components/CategoryFilter.tsx
@@ -1,0 +1,34 @@
+type CategoryFilterProps = {
+  id: string;
+  label: string;
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export const CategoryFilter = ({
+  id,
+  label,
+  options,
+  value,
+  onChange,
+}: CategoryFilterProps) => (
+  <div>
+    <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+      {label}
+    </label>
+    <select
+      id={id}
+      className="border border-gray-300 rounded-md p-2 mt-1 text-sm"
+      value={value}
+      onChange={(e) => onChange(e.currentTarget.value)}
+    >
+      <option value="">Any</option>
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  </div>
+);

--- a/src/app/components/RangeFilter.tsx
+++ b/src/app/components/RangeFilter.tsx
@@ -1,0 +1,33 @@
+type RangeFilterProps = {
+  id: string;
+  label: string;
+  ranges: { label: string; min: number; max: number }[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export const RangeFilter = ({
+  id,
+  label,
+  ranges,
+  value,
+  onChange,
+}: RangeFilterProps) => (
+  <div>
+    <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+      {label}
+    </label>
+    <select
+      id={id}
+      className="border border-gray-300 rounded-md p-2 mt-1 text-sm"
+      value={value}
+      onChange={(e) => onChange(e.currentTarget.value)}
+    >
+      {ranges.map((range) => (
+        <option key={range.label} value={range.label}>
+          {range.label}
+        </option>
+      ))}
+    </select>
+  </div>
+);

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -4,18 +4,18 @@ type SearchBarProps = {
   value: string;
   label: string;
   placeholder: string;
-  onChange: (value: string) => void;
+  setSearchTerm: (value: string) => void;
 };
 
 export const SearchBar = ({
   value,
-  onChange,
+  setSearchTerm,
   placeholder,
   label,
 }: SearchBarProps) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const searchTermValue = e.currentTarget.value;
-    onChange(searchTermValue);
+    setSearchTerm(searchTermValue);
   };
   return (
     <>

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -1,0 +1,34 @@
+import { ChangeEvent } from "react";
+
+type SearchBarProps = {
+  value: string;
+  label: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+};
+
+export const SearchBar = ({
+  value,
+  onChange,
+  placeholder,
+  label,
+}: SearchBarProps) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const searchTermValue = e.currentTarget.value;
+    onChange(searchTermValue);
+  };
+  return (
+    <>
+      <label htmlFor="search" className="sr-only">
+        {label}
+      </label>
+      <input
+        id="search"
+        className="border border-gray-300 rounded-md p-2 w-full md:w-2/3"
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+      />
+    </>
+  );
+};

--- a/src/app/hooks/useAdvocates.ts
+++ b/src/app/hooks/useAdvocates.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { Advocate } from "../shared/types";
+
+const API_ENDPOINT = "/api/advocates";
+
+async function fetchData<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch data from ${url}`);
+  }
+  return response.json();
+}
+
+export function useAdvocates() {
+  const [advocates, setAdvocates] = useState<Advocate[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchAdvocates = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const { data } = await fetchData<{ data: Advocate[] }>(API_ENDPOINT);
+        setAdvocates(data);
+      } catch (e) {
+        setError("Failed to fetch advocates.");
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAdvocates();
+  }, []);
+
+  return { advocates, loading, error };
+}

--- a/src/app/hooks/useDynamicFilterOptions.ts
+++ b/src/app/hooks/useDynamicFilterOptions.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { Advocate, DynamicFilterOptions } from "../shared/types";
+
+export function useDynamicFilterOptions(
+  advocates: Advocate[]
+): DynamicFilterOptions {
+  return useMemo(() => {
+    const specialties = new Set<string>();
+    const cities = new Set<string>();
+    const degrees = new Set<string>();
+
+    advocates.forEach((advocate) => {
+      advocate.specialties.forEach((specialty) => specialties.add(specialty));
+      cities.add(advocate.city);
+      degrees.add(advocate.degree);
+    });
+
+    return {
+      specialties: Array.from(specialties),
+      cities: Array.from(cities),
+      degrees: Array.from(degrees),
+    };
+  }, [advocates]);
+}

--- a/src/app/hooks/useRefineAdvocates.ts
+++ b/src/app/hooks/useRefineAdvocates.ts
@@ -32,7 +32,7 @@ export function useRefineAdvocates(advocates: Advocate[]) {
 
       const matchesSearch =
         fullName.includes(lowerCaseSearchTerm) ||
-        ["city", "degree", "phoneNumber"].some((key) => {
+        ["city", "degree", "specialties"].some((key) => {
           const value = advocate[key as keyof Advocate];
           return String(value).toLowerCase().includes(lowerCaseSearchTerm);
         });

--- a/src/app/hooks/useRefineAdvocates.ts
+++ b/src/app/hooks/useRefineAdvocates.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo, useState } from "react";
+import { Advocate, ActiveFilterValues } from "../shared/types";
+import { useDynamicFilterOptions } from "./useDynamicFilterOptions";
+
+const EXPERIENCE_RANGES = [
+  { label: "Any", min: 0, max: Infinity },
+  { label: "Less than 1 year", min: 0, max: 1 },
+  { label: "1 to 5 years", min: 1, max: 5 },
+  { label: "5 to 10 years", min: 5, max: 10 },
+  { label: "10+ years", min: 10, max: Infinity },
+];
+
+const DEFAULT_ACTIVE_FILTERS: ActiveFilterValues = {
+  specialty: "",
+  city: "",
+  degree: "",
+  experienceRange: "Any",
+};
+
+export function useRefineAdvocates(advocates: Advocate[]) {
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [activeFilters, setActiveFilters] = useState<ActiveFilterValues>(
+    DEFAULT_ACTIVE_FILTERS
+  );
+  const dynamicFilterOptions = useDynamicFilterOptions(advocates);
+  const refinedAdvocates = useMemo(() => {
+    return advocates.filter((advocate) => {
+      const lowerCaseSearchTerm = searchTerm.toLowerCase();
+      // I want to allow searching for the full name. So John Doe etc.
+      const fullName =
+        `${advocate.firstName} ${advocate.lastName}`.toLowerCase();
+
+      const matchesSearch =
+        fullName.includes(lowerCaseSearchTerm) ||
+        ["city", "degree", "phoneNumber"].some((key) => {
+          const value = advocate[key as keyof Advocate];
+          return String(value).toLowerCase().includes(lowerCaseSearchTerm);
+        });
+
+      const matchesSpecialty =
+        !activeFilters.specialty ||
+        advocate.specialties.includes(activeFilters.specialty);
+
+      const matchesCity =
+        !activeFilters.city || advocate.city === activeFilters.city;
+
+      const matchesDegree =
+        !activeFilters.degree || advocate.degree === activeFilters.degree;
+
+      const selectedRange = EXPERIENCE_RANGES.find(
+        (range) => range.label === activeFilters.experienceRange
+      );
+
+      const matchesExperience =
+        selectedRange &&
+        advocate.yearsOfExperience >= selectedRange.min &&
+        advocate.yearsOfExperience < selectedRange.max;
+
+      return (
+        matchesSearch &&
+        matchesSpecialty &&
+        matchesCity &&
+        matchesDegree &&
+        matchesExperience
+      );
+    });
+  }, [advocates, searchTerm, activeFilters]);
+
+  const resetSearchAndFilters = useCallback(() => {
+    setSearchTerm("");
+    setActiveFilters(DEFAULT_ACTIVE_FILTERS);
+  }, []);
+
+  return {
+    refinedAdvocates,
+    dynamicFilterOptions,
+    searchTerm,
+    setSearchTerm,
+    activeFilters,
+    setActiveFilters,
+    resetSearchAndFilters,
+    experienceRanges: EXPERIENCE_RANGES,
+  };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChangeEvent, useEffect, useMemo, useState } from "react";
+import { AdvocatesTable } from "./components/AdvocatesTable";
 
 type Advocate = {
   id: number;
@@ -292,76 +293,7 @@ export default function Home() {
         </div>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full table-auto border-collapse border border-gray-200 text-sm">
-          <thead className="bg-gray-100 text-gray-600 uppercase text-xs font-semibold">
-            <tr>
-              <th className="border border-gray-300 px-4 py-2 text-left">
-                First Name
-              </th>
-              <th className="border border-gray-300 px-4 py-2 text-left">
-                Last Name
-              </th>
-              <th className="border border-gray-300 px-4 py-2 text-left">
-                City
-              </th>
-              <th className="border border-gray-300 px-4 py-2 text-left">
-                Degree
-              </th>
-              <th className="border border-gray-300 px-4 py-2 text-left hidden md:table-cell">
-                Specialties
-              </th>
-              <th className="border border-gray-300 px-4 py-2 text-left">
-                Years of Experience
-              </th>
-              <th className="border border-gray-300 px-4 py-2 text-left hidden sm:table-cell">
-                Phone Number
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {filterAndSearchAdvocates.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={7}
-                  className="border border-gray-300 px-4 py-6 text-center text-gray-600"
-                >
-                  No advocates found.
-                </td>
-              </tr>
-            ) : (
-              filterAndSearchAdvocates.map((advocate) => (
-                <tr
-                  key={advocate.id}
-                  className="hover:bg-gray-50 transition-colors duration-200"
-                >
-                  <td className="border border-gray-300 px-4 py-2">
-                    {advocate.firstName}
-                  </td>
-                  <td className="border border-gray-300 px-4 py-2">
-                    {advocate.lastName}
-                  </td>
-                  <td className="border border-gray-300 px-4 py-2">
-                    {advocate.city}
-                  </td>
-                  <td className="border border-gray-300 px-4 py-2">
-                    {advocate.degree}
-                  </td>
-                  <td className="border border-gray-300 px-4 py-2 hidden md:table-cell">
-                    {advocate.specialties.join(", ")}
-                  </td>
-                  <td className="border border-gray-300 px-4 py-2">
-                    {advocate.yearsOfExperience}
-                  </td>
-                  <td className="border border-gray-300 px-4 py-2 hidden sm:table-cell">
-                    {advocate.phoneNumber}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+      <AdvocatesTable advocates={filterAndSearchAdvocates} />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ const DEFAULT_ACTIVE_FILTERS: ActiveFilterValues = {
 };
 
 export default function Home() {
-  const { advocates } = useAdvocates();
+  const { advocates, loading, error } = useAdvocates();
   const {
     refinedAdvocates,
     activeFilters,
@@ -40,6 +40,12 @@ export default function Home() {
     resetSearchAndFilters,
     dynamicFilterOptions,
   } = useRefineAdvocates(advocates);
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    return <div>{error}</div>;
+  }
   return (
     <main className="m-6">
       <h1 className="text-3xl font-bold mb-6">Solace Advocates</h1>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -320,34 +320,45 @@ export default function Home() {
             </tr>
           </thead>
           <tbody>
-            {filterAndSearchAdvocates.map((advocate) => (
-              <tr
-                key={advocate.id}
-                className="hover:bg-gray-50 transition-colors duration-200"
-              >
-                <td className="border border-gray-300 px-4 py-2">
-                  {advocate.firstName}
-                </td>
-                <td className="border border-gray-300 px-4 py-2">
-                  {advocate.lastName}
-                </td>
-                <td className="border border-gray-300 px-4 py-2">
-                  {advocate.city}
-                </td>
-                <td className="border border-gray-300 px-4 py-2">
-                  {advocate.degree}
-                </td>
-                <td className="border border-gray-300 px-4 py-2 hidden md:table-cell">
-                  {advocate.specialties.join(", ")}
-                </td>
-                <td className="border border-gray-300 px-4 py-2">
-                  {advocate.yearsOfExperience}
-                </td>
-                <td className="border border-gray-300 px-4 py-2 hidden sm:table-cell">
-                  {advocate.phoneNumber}
+            {filterAndSearchAdvocates.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="border border-gray-300 px-4 py-6 text-center text-gray-600"
+                >
+                  No advocates found.
                 </td>
               </tr>
-            ))}
+            ) : (
+              filterAndSearchAdvocates.map((advocate) => (
+                <tr
+                  key={advocate.id}
+                  className="hover:bg-gray-50 transition-colors duration-200"
+                >
+                  <td className="border border-gray-300 px-4 py-2">
+                    {advocate.firstName}
+                  </td>
+                  <td className="border border-gray-300 px-4 py-2">
+                    {advocate.lastName}
+                  </td>
+                  <td className="border border-gray-300 px-4 py-2">
+                    {advocate.city}
+                  </td>
+                  <td className="border border-gray-300 px-4 py-2">
+                    {advocate.degree}
+                  </td>
+                  <td className="border border-gray-300 px-4 py-2 hidden md:table-cell">
+                    {advocate.specialties.join(", ")}
+                  </td>
+                  <td className="border border-gray-300 px-4 py-2">
+                    {advocate.yearsOfExperience}
+                  </td>
+                  <td className="border border-gray-300 px-4 py-2 hidden sm:table-cell">
+                    {advocate.phoneNumber}
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { ChangeEvent, useEffect, useMemo, useState } from "react";
 import { AdvocatesTable } from "./components/AdvocatesTable";
+import { SearchBar } from "./components/SearchBar";
 
 type Advocate = {
   id: number;
@@ -68,6 +69,7 @@ const filterAdvocates = (
 export default function Home() {
   const [advocates, setAdvocates] = useState<Advocate[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
+  const handleSearchChange = (term: string) => setSearchTerm(term);
   const [filters, setFilters] = useState<FilterValues>({
     specialty: "",
     city: "",
@@ -116,11 +118,6 @@ export default function Home() {
     };
     fetchAdvocates();
   }, []);
-
-  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const searchTermValue = e.currentTarget.value;
-    setSearchTerm(searchTermValue);
-  };
 
   const resetSearchAndFilters = () => {
     setSearchTerm("");
@@ -179,16 +176,13 @@ export default function Home() {
 
       <div className="mb-6 flex flex-col gap-4">
         <div className="flex gap-4 items-center">
-          <label htmlFor="search" className="sr-only">
-            Search by Name, City, Degree, or Phone Number
-          </label>
-          <input
-            id="search"
-            className="border border-gray-300 rounded-md p-2 w-full text-sm md:w-2/3"
-            placeholder="Search advocates"
+          <SearchBar
             value={searchTerm}
             onChange={handleSearchChange}
+            placeholder="Search advocates"
+            label="Search by Name, City, Degree, or Phone Number"
           />
+
           <button
             className="bg-green-700 text-white font-semibold py-2 px-6 rounded-lg shadow-md hover:bg-green-800"
             onClick={resetSearchAndFilters}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,27 @@ type Advocate = {
   phoneNumber: number;
 };
 
+type DynamicFilterOptions = {
+  specialties: string[];
+  cities: string[];
+  degrees: string[];
+};
+
+type FilterValues = {
+  specialty: string;
+  city: string;
+  degree: string;
+  experienceRange: string;
+};
+
+const EXPERIENCE_RANGES = [
+  { label: "Any", min: 0, max: Infinity },
+  { label: "Less than 1 year", min: 0, max: 1 },
+  { label: "1 to 5 years", min: 1, max: 5 },
+  { label: "5 to 10 years", min: 5, max: 10 },
+  { label: "10+ years", min: 10, max: Infinity },
+];
+
 async function fetchData<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
@@ -46,15 +67,47 @@ const filterAdvocates = (
 export default function Home() {
   const [advocates, setAdvocates] = useState<Advocate[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
+  const [filters, setFilters] = useState<FilterValues>({
+    specialty: "",
+    city: "",
+    degree: "",
+    experienceRange: "Any",
+  });
+
+  // I am opting to gather category filter options once here as opposed to calculating after each filter change.
+  const [dynamicFilterOptions, setDynamicFilterOptions] =
+    useState<DynamicFilterOptions>({
+      specialties: [],
+      cities: [],
+      degrees: [],
+    });
 
   useEffect(() => {
-    console.log("fetching advocates...");
     const fetchAdvocates = async () => {
       try {
         const response = await fetchData<{ data: Advocate[] }>(
           "/api/advocates"
         );
-        setAdvocates(response.data || []);
+        const data = response.data;
+        setAdvocates(data);
+
+        const specialties = new Set<string>();
+        const cities = new Set<string>();
+        const degrees = new Set<string>();
+
+        data.forEach((advocate) => {
+          advocate.specialties.forEach((specialty) =>
+            specialties.add(specialty)
+          );
+          cities.add(advocate.city);
+          degrees.add(advocate.degree);
+        });
+
+        setDynamicFilterOptions({
+          specialties: Array.from(specialties),
+          cities: Array.from(cities),
+          degrees: Array.from(degrees),
+        });
       } catch (e) {
         // TODO: Properly handle error in UI.
         console.error(e);
@@ -68,15 +121,56 @@ export default function Home() {
     setSearchTerm(searchTermValue);
   };
 
-  const resetSearch = () => {
-    console.log(advocates);
+  const resetSearchAndFilters = () => {
     setSearchTerm("");
+    setFilters({
+      specialty: "",
+      city: "",
+      degree: "",
+      experienceRange: "Any",
+    });
   };
 
-  const filteredAdvocates = useMemo(
-    () => filterAdvocates(searchTerm, advocates),
-    [searchTerm, advocates]
-  );
+  const filterAndSearchAdvocates = useMemo(() => {
+    return advocates.filter((advocate) => {
+      const lowerCaseSearchTerm = searchTerm.toLowerCase();
+      // I want to allow searching for the full name. So John Doe etc.
+      const fullName =
+        `${advocate.firstName} ${advocate.lastName}`.toLowerCase();
+
+      const matchesSearch =
+        fullName.includes(lowerCaseSearchTerm) || // Match full name
+        ["city", "degree", "phoneNumber"].some((key) => {
+          const value = advocate[key as keyof Advocate];
+          return String(value).toLowerCase().includes(lowerCaseSearchTerm);
+        });
+
+      const matchesSpecialty =
+        !filters.specialty || advocate.specialties.includes(filters.specialty);
+
+      const matchesCity = !filters.city || advocate.city === filters.city;
+
+      const matchesDegree =
+        !filters.degree || advocate.degree === filters.degree;
+
+      const selectedRange = EXPERIENCE_RANGES.find(
+        (range) => range.label === filters.experienceRange
+      );
+
+      const matchesExperience =
+        selectedRange &&
+        advocate.yearsOfExperience >= selectedRange.min &&
+        advocate.yearsOfExperience < selectedRange.max;
+
+      return (
+        matchesSearch &&
+        matchesSpecialty &&
+        matchesCity &&
+        matchesDegree &&
+        matchesExperience
+      );
+    });
+  }, [advocates, searchTerm, filters]);
 
   return (
     <main className="m-6">
@@ -89,7 +183,101 @@ export default function Home() {
           Searching for: <span>{searchTerm}</span>
         </p>
         <input className="border border-black" onChange={handleSearchChange} />
-        <button onClick={resetSearch}>Reset Search</button>
+        <button onClick={resetSearchAndFilters}>Reset Search</button>
+      </div>
+      <br />
+      <br />
+      <div className="flex flex-wrap gap-4">
+        <div>
+          <label
+            htmlFor="specialty"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Specialty
+          </label>
+          <select
+            id="specialty"
+            className="border border-gray-300 rounded-md p-2 mt-1"
+            value={filters.specialty}
+            onChange={(e) =>
+              setFilters({ ...filters, specialty: e.target.value })
+            }
+          >
+            <option value="">All Specialties</option>
+            {dynamicFilterOptions.specialties.map((specialty) => (
+              <option key={specialty} value={specialty}>
+                {specialty}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="city"
+            className="block text-sm font-medium text-gray-700"
+          >
+            City
+          </label>
+          <select
+            id="city"
+            className="border border-gray-300 rounded-md p-2 mt-1"
+            value={filters.city}
+            onChange={(e) => setFilters({ ...filters, city: e.target.value })}
+          >
+            <option value="">All Cities</option>
+            {dynamicFilterOptions.cities.map((city) => (
+              <option key={city} value={city}>
+                {city}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="degree"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Degree
+          </label>
+          <select
+            id="degree"
+            className="border border-gray-300 rounded-md p-2 mt-1"
+            value={filters.degree}
+            onChange={(e) => setFilters({ ...filters, degree: e.target.value })}
+          >
+            <option value="">All Degrees</option>
+            {dynamicFilterOptions.degrees.map((degree) => (
+              <option key={degree} value={degree}>
+                {degree}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="experienceRange"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Years of Experience
+          </label>
+          <select
+            id="experienceRange"
+            className="border border-gray-300 rounded-md p-2 mt-1"
+            value={filters.experienceRange}
+            onChange={(e) =>
+              setFilters({ ...filters, experienceRange: e.target.value })
+            }
+          >
+            {EXPERIENCE_RANGES.map((range) => (
+              <option key={range.label} value={range.label}>
+                {range.label}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
       <br />
       <br />
@@ -106,7 +294,7 @@ export default function Home() {
           </tr>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {filterAndSearchAdvocates.map((advocate) => {
             return (
               <tr key={advocate.id}>
                 <td>{advocate.firstName}</td>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,145 +174,183 @@ export default function Home() {
 
   return (
     <main className="m-6">
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span>{searchTerm}</span>
-        </p>
-        <input className="border border-black" onChange={handleSearchChange} />
-        <button onClick={resetSearchAndFilters}>Reset Search</button>
+      <h1 className="text-3xl font-bold mb-6">Solace Advocates</h1>
+
+      <div className="mb-6 flex flex-col gap-4">
+        <div className="flex gap-4 items-center">
+          <label htmlFor="search" className="sr-only">
+            Search by Name, City, Degree, or Phone Number
+          </label>
+          <input
+            id="search"
+            className="border border-gray-300 rounded-md p-2 w-full text-sm md:w-2/3"
+            placeholder="Search advocates"
+            value={searchTerm}
+            onChange={handleSearchChange}
+          />
+          <button
+            className="bg-green-700 text-white font-semibold py-2 px-6 rounded-lg shadow-md hover:bg-green-800"
+            onClick={resetSearchAndFilters}
+          >
+            Reset
+          </button>
+        </div>
+
+        <div className="flex flex-wrap gap-4">
+          <div>
+            <label
+              htmlFor="specialty"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Specialty
+            </label>
+            <select
+              id="specialty"
+              className="border border-gray-300 rounded-md p-2 mt-1 text-sm"
+              value={filters.specialty}
+              onChange={(e) =>
+                setFilters({ ...filters, specialty: e.target.value })
+              }
+            >
+              <option value="">All Specialties</option>
+              {dynamicFilterOptions.specialties.map((specialty) => (
+                <option key={specialty} value={specialty}>
+                  {specialty}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="city"
+              className="block text-sm font-medium text-gray-700"
+            >
+              City
+            </label>
+            <select
+              id="city"
+              className="border border-gray-300 rounded-md p-2 mt-1 text-sm"
+              value={filters.city}
+              onChange={(e) => setFilters({ ...filters, city: e.target.value })}
+            >
+              <option value="">All Cities</option>
+              {dynamicFilterOptions.cities.map((city) => (
+                <option key={city} value={city}>
+                  {city}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="degree"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Degree
+            </label>
+            <select
+              id="degree"
+              className="border border-gray-300 rounded-md p-2 mt-1 text-sm"
+              value={filters.degree}
+              onChange={(e) =>
+                setFilters({ ...filters, degree: e.target.value })
+              }
+            >
+              <option value="">All Degrees</option>
+              {dynamicFilterOptions.degrees.map((degree) => (
+                <option key={degree} value={degree}>
+                  {degree}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="experienceRange"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Years of Experience
+            </label>
+            <select
+              id="experienceRange"
+              className="border border-gray-300 rounded-md p-2 mt-1 text-sm"
+              value={filters.experienceRange}
+              onChange={(e) =>
+                setFilters({ ...filters, experienceRange: e.target.value })
+              }
+            >
+              {EXPERIENCE_RANGES.map((range) => (
+                <option key={range.label} value={range.label}>
+                  {range.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
       </div>
-      <br />
-      <br />
-      <div className="flex flex-wrap gap-4">
-        <div>
-          <label
-            htmlFor="specialty"
-            className="block text-sm font-medium text-gray-700"
-          >
-            Specialty
-          </label>
-          <select
-            id="specialty"
-            className="border border-gray-300 rounded-md p-2 mt-1"
-            value={filters.specialty}
-            onChange={(e) =>
-              setFilters({ ...filters, specialty: e.target.value })
-            }
-          >
-            <option value="">All Specialties</option>
-            {dynamicFilterOptions.specialties.map((specialty) => (
-              <option key={specialty} value={specialty}>
-                {specialty}
-              </option>
-            ))}
-          </select>
-        </div>
 
-        <div>
-          <label
-            htmlFor="city"
-            className="block text-sm font-medium text-gray-700"
-          >
-            City
-          </label>
-          <select
-            id="city"
-            className="border border-gray-300 rounded-md p-2 mt-1"
-            value={filters.city}
-            onChange={(e) => setFilters({ ...filters, city: e.target.value })}
-          >
-            <option value="">All Cities</option>
-            {dynamicFilterOptions.cities.map((city) => (
-              <option key={city} value={city}>
-                {city}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label
-            htmlFor="degree"
-            className="block text-sm font-medium text-gray-700"
-          >
-            Degree
-          </label>
-          <select
-            id="degree"
-            className="border border-gray-300 rounded-md p-2 mt-1"
-            value={filters.degree}
-            onChange={(e) => setFilters({ ...filters, degree: e.target.value })}
-          >
-            <option value="">All Degrees</option>
-            {dynamicFilterOptions.degrees.map((degree) => (
-              <option key={degree} value={degree}>
-                {degree}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label
-            htmlFor="experienceRange"
-            className="block text-sm font-medium text-gray-700"
-          >
-            Years of Experience
-          </label>
-          <select
-            id="experienceRange"
-            className="border border-gray-300 rounded-md p-2 mt-1"
-            value={filters.experienceRange}
-            onChange={(e) =>
-              setFilters({ ...filters, experienceRange: e.target.value })
-            }
-          >
-            {EXPERIENCE_RANGES.map((range) => (
-              <option key={range.label} value={range.label}>
-                {range.label}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <tr>
-            <th>First Name</th>
-            <th>Last Name</th>
-            <th>City</th>
-            <th>Degree</th>
-            <th>Specialties</th>
-            <th>Years of Experience</th>
-            <th>Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filterAndSearchAdvocates.map((advocate) => {
-            return (
-              <tr key={advocate.id}>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
-                  {advocate.specialties.map((s) => (
-                    <div key={s}>{s}</div>
-                  ))}
+      <div className="overflow-x-auto">
+        <table className="w-full table-auto border-collapse border border-gray-200 text-sm">
+          <thead className="bg-gray-100 text-gray-600 uppercase text-xs font-semibold">
+            <tr>
+              <th className="border border-gray-300 px-4 py-2 text-left">
+                First Name
+              </th>
+              <th className="border border-gray-300 px-4 py-2 text-left">
+                Last Name
+              </th>
+              <th className="border border-gray-300 px-4 py-2 text-left">
+                City
+              </th>
+              <th className="border border-gray-300 px-4 py-2 text-left">
+                Degree
+              </th>
+              <th className="border border-gray-300 px-4 py-2 text-left hidden md:table-cell">
+                Specialties
+              </th>
+              <th className="border border-gray-300 px-4 py-2 text-left">
+                Years of Experience
+              </th>
+              <th className="border border-gray-300 px-4 py-2 text-left hidden sm:table-cell">
+                Phone Number
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filterAndSearchAdvocates.map((advocate) => (
+              <tr
+                key={advocate.id}
+                className="hover:bg-gray-50 transition-colors duration-200"
+              >
+                <td className="border border-gray-300 px-4 py-2">
+                  {advocate.firstName}
                 </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
+                <td className="border border-gray-300 px-4 py-2">
+                  {advocate.lastName}
+                </td>
+                <td className="border border-gray-300 px-4 py-2">
+                  {advocate.city}
+                </td>
+                <td className="border border-gray-300 px-4 py-2">
+                  {advocate.degree}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 hidden md:table-cell">
+                  {advocate.specialties.join(", ")}
+                </td>
+                <td className="border border-gray-300 px-4 py-2">
+                  {advocate.yearsOfExperience}
+                </td>
+                <td className="border border-gray-300 px-4 py-2 hidden sm:table-cell">
+                  {advocate.phoneNumber}
+                </td>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </main>
   );
 }

--- a/src/app/shared/fetchData.ts
+++ b/src/app/shared/fetchData.ts
@@ -1,0 +1,7 @@
+export async function fetchData<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch data from ${url}`);
+  }
+  return response.json();
+}

--- a/src/app/shared/types.ts
+++ b/src/app/shared/types.ts
@@ -1,0 +1,10 @@
+export type Advocate = {
+  id: number;
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: number;
+  phoneNumber: number;
+};

--- a/src/app/shared/types.ts
+++ b/src/app/shared/types.ts
@@ -8,3 +8,16 @@ export type Advocate = {
   yearsOfExperience: number;
   phoneNumber: number;
 };
+
+export type DynamicFilterOptions = {
+  specialties: string[];
+  cities: string[];
+  degrees: string[];
+};
+
+export type ActiveFilterValues = {
+  specialty: string;
+  city: string;
+  degree: string;
+  experienceRange: string;
+};


### PR DESCRIPTION
This PR builds on the fixed introduced in PR #1 and focuses on making improvements to the aesthetic, user experience, and performance. It includes:

**Adding filters in addition to the search.** 
* Adding filters for Speciality, City, Degree, and Years of Experience to give users a quick way to quickly get to the results that are important to them. I think these filters are good categorical filters that make more sense as a filter as opposed to a search.
* Making sure searching by full name would still return results.
* Also omitting years of experience and phone number, from the search. This would normally be a decision made after user testing, but I don't know if searching for years or phone numbers is a strong use case for search.

**Adding styling with tailwind**
* Updating the styles for a nicer look and feel.
* Improving usability across devices by introducing some responsive design elements to the table. This includes dynamically hiding non-critical columns based on screen size. Ideally, there would be a way to click into more details or choose which columns are shown.

**Adding a no results display**
* Giving a user some more feedback when results are aren't found.

**Creating contained components for displaying**
* Adding modular more reusable components for category filters, range filters, the Advocates table, and search bar.
* These components display components that rely on input which are more easily testable.

**Creating hooks for searching, filtering and fetching advocates. Each coming optimized to avoid re-renders**
* Fetching advocates. `useAdvocates`.
* Filtering and searching advocates. `useRefineAdvocates`.
* Generating dynamic filter options for the categorical filters. `useDynamicFilterOptions`.
* These hooks can be mocked in larger integration tests and can be tested individually.

**Introducing loading loading and error states**
* Giving some visual feedback as to the progress of the request.

**Caching the GET request**
* Opting in to Next's `revalidate` and `force-static` route config option as a small win for data that shouldn't change that often.

**Making sure the .env is in the .gitignore**
* Ensuring that the env isn't being exposed by mistake.

While filtering and searching are handled on the frontend for now, this implementation could serve as a proof of concept for moving the logic to the backend. These changes can help validate a users experience and workflow before investing in a larger more scalable backend solution. 